### PR TITLE
Create initial MVP functionality

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Vite App</title>
+  </head>
+<body>
+  <div id="app"></div>
+  <script type="module" src="/src/index.ts"></script>
+</body>
+</html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,15 @@
 {
-  "name": "@keeoth/chronicle",
-  "version": "0.5.1",
+  "name": "@keeoth/observatory",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@keeoth/chronicle",
-      "version": "0.5.1",
+      "name": "@keeoth/observatory",
+      "version": "0.1.0",
+      "dependencies": {
+        "rxjs": "^7.8.1"
+      },
       "devDependencies": {
         "@antfu/eslint-config": "^2.6.3",
         "@types/node": "^20.11.5",
@@ -5114,6 +5117,14 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/rxjs": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
+      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
     "node_modules/semver": {
       "version": "7.5.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
@@ -5510,8 +5521,7 @@
     "node_modules/tslib": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
-      "dev": true
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -38,5 +38,8 @@
   },
   "lint-staged": {
     "*.ts": "npm run lint"
+  },
+  "dependencies": {
+    "rxjs": "^7.8.1"
   }
 }

--- a/src/Observatory/observatory.test.ts
+++ b/src/Observatory/observatory.test.ts
@@ -1,15 +1,32 @@
 import { describe, expect, it, vi } from 'vitest'
+import { createObservatory } from './'
 
-
-describe('createChronicle', () => {
-  it('should create an initial Event on Chronicle creation', () => {
+describe('createObservatory', () => {
+  it('should be able to make logs', () => {
     // Setup
-    // const initialEvent = 'Initial event'
+    const callbackForLog = vi.fn()
+    const callbackForError = vi.fn()
 
-    // // Test
-    // const chronicle = createChronicle(initialEvent)
+    const { logObservation } = createObservatory<string>()
+      .addObserver({
+        levelsToObserve: ['LOG'],
+        onObservation(observation) {
+          callbackForLog(observation)
+        },
+      })
+      .addObserver({
+        levelsToObserve: ['ERROR'],
+        onObservation(observation) {
+          callbackForError(observation)
+        },
+      })
 
-    // // Assert
-    // expect(chronicle.getCurrentEvent()).toEqual(initialEvent)
+    // Test
+    logObservation('ERROR', 'SOME ERROR!')
+    logObservation('LOG', 'SOME LOG!')
+
+    // Setup
+    expect(callbackForError).toHaveBeenCalledOnce()
+    expect(callbackForLog).toHaveBeenCalledOnce()
   })
 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,3 @@
-export { createChronicle } from './Observatory'
-export type { Chronicle } from './Observatory'
+export { createObservatory } from './Observatory'
 
+export type { Observatory, Observer, Observation } from './Observatory'


### PR DESCRIPTION
With these changes, we have basic logging functionality done.

* Conditionally add Observers with each scoped to their discrete set of Observation Levels
* Conditionally run individual observation events via `when` param on `logObservation`